### PR TITLE
Expanded support for bounces.get

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,10 +12,11 @@ version = 0.001
 
 [Prereqs]
 IO::Socket::SSL = 1.44  ; version I've tested with
-Mouse
-HTTP::Tiny
-XML::Simple
-JSON
+Mouse = 0
+HTTP::Tiny = 0
+XML::Simple = 0
+JSON = 0
+URI::Escape = 0
 
 [PodWeaver]
 

--- a/example/bounces.pl
+++ b/example/bounces.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+use Mail::SendGrid;
+use Getopt::Long;
+
+
+my %opt;
+GetOptions( \%opt, 'help|h', 'username|u=s', 'password|p=s', 
+    'start_date|s:s', 'end_date|e:s', 'days|d:i', 'limit|l:i', 'offset|s:i',
+    'type|t:s', 'email|e:s') or usage();
+usage() if !$opt{username} or !$opt{password} or $opt{help};
+
+my $sendgrid = Mail::SendGrid->new(
+    api_user => delete $opt{username},
+    api_key => delete $opt{password},
+);
+
+for my $bounce ($sendgrid->bounces(\%opt)) {
+    print "Bounce: " . $bounce->email. "\n";
+}
+
+
+sub usage {
+    print <<USAGE;
+$0: bounces.pl [opts]
+
+Options:
+username   (string) REQUIRED. SendGrid username (api_user)
+password   (string) REQUIRED. SendGrid password (api_key)
+days       (int)    Number of days in the past to retrieve (includes today)
+start_date (string) Start date of date range (YYYY-MM-DD)
+send_date  (string) End date of date range (YYYY-MM-DD)
+limit      (int)    Limit number of results returned
+offset     (int)    Beginning point in the list to retrieve from
+USAGE
+    die 0;
+}


### PR DESCRIPTION
Hi Neil,
We're using SendGrid at $work so I thought I'd contribute back some changes. I switched to the JSON output by default because some of my bounce reasons triggered XML::Simple to think it needed a hashref instead of a string. The JSON parsing of the same list caused no errors.

Drew
